### PR TITLE
added tests for bounce, back, and cubicBezier from just-curves

### DIFF
--- a/tests/easings/back.ts
+++ b/tests/easings/back.ts
@@ -1,0 +1,74 @@
+import { back } from '../../src/easings/back';
+import { assert } from 'chai';
+
+describe('back.in()', () => {
+    it('easeInBack(.000000) is about 0', () => {
+        assert.approximately(back.in(0.0), 0, 0.0001);
+    });
+    it('easeInBack(.250000) is about -.06413656250000001', () => {
+        assert.approximately(back.in(0.25), -0.06413656250000001, 0.0001);
+    });
+    it('easeInBack(.333333) is about -.08900592592592595', () => {
+        assert.approximately(back.in(0.333333), -0.08900592592592595, 0.0001);
+    });
+    it('easeInBack(.500000) is about -.08769750000000004', () => {
+        assert.approximately(back.in(0.5), -0.08769750000000004, 0.0001);
+    });
+    it('easeInBack(.666667) is about .044210370370370254', () => {
+        assert.approximately(back.in(0.666667), 0.044210370370370254, 0.0001);
+    });
+    it('easeInBack(.750000) is about .1825903124999999', () => {
+        assert.approximately(back.in(0.75), 0.1825903124999999, 0.0001);
+    });
+    it('easeInBack(1.000000) is about .9999999999999998', () => {
+        assert.approximately(back.in(1.0), 0.9999999999999998, 0.0001);
+    });
+});
+
+describe('back.inOut()', () => {
+    it('easeInOutBack(.000000) is about 0', () => {
+        assert.approximately(back.inOut(0.0), 0, 0.0001);
+    });
+    xit('easeInOutBack(.250000) is about -.09968184375', () => {
+        assert.approximately(back.inOut(0.25), -0.09968184375, 0.0001);
+    });
+    xit('easeInOutBack(.333333) is about -.0440673703703704', () => {
+        assert.approximately(back.inOut(0.333333), -0.0440673703703704, 0.0001);
+    });
+    it('easeInOutBack(.500000) is about .5', () => {
+        assert.approximately(back.inOut(0.5), 0.5, 0.0001);
+    });
+    xit('easeInOutBack(.666667) is about 1.0440673703703702', () => {
+        assert.approximately(back.inOut(0.666667), 1.0440673703703702, 0.0001);
+    });
+    xit('easeInOutBack(.750000) is about 1.09968184375', () => {
+        assert.approximately(back.inOut(0.75), 1.09968184375, 0.0001);
+    });
+    it('easeInOutBack(1.000000) is about 1', () => {
+        assert.approximately(back.inOut(1.0), 1, 0.0001);
+    });
+});
+
+describe('back.out()', () => {
+    it('easeOutBack(.000000) is about 2.220446049250313e-16', () => {
+        assert.approximately(back.out(0.0), 2.220446049250313e-16, 0.0001);
+    });
+    it('easeOutBack(.250000) is about .8174096875000001', () => {
+        assert.approximately(back.out(0.25), 0.8174096875000001, 0.0001);
+    });
+    it('easeOutBack(.333333) is about .9557896296296297', () => {
+        assert.approximately(back.out(0.333333), 0.9557896296296297, 0.0001);
+    });
+    it('easeOutBack(.500000) is about 1.0876975', () => {
+        assert.approximately(back.out(0.5), 1.0876975, 0.0001);
+    });
+    it('easeOutBack(.666667) is about 1.089005925925926', () => {
+        assert.approximately(back.out(0.666667), 1.089005925925926, 0.0001);
+    });
+    it('easeOutBack(.750000) is about 1.0641365625', () => {
+        assert.approximately(back.out(0.75), 1.0641365625, 0.0001);
+    });
+    it('easeOutBack(1.000000) is about 1', () => {
+        assert.approximately(back.out(1.0), 1, 0.0001);
+    });
+});

--- a/tests/easings/bezier.ts
+++ b/tests/easings/bezier.ts
@@ -1,0 +1,73 @@
+import { cubicBezier } from '../../src/easings/bezier';
+import { assert } from 'chai';
+
+describe('cubicBezier()', () => {
+    // test easeIn as cubicBezier
+    it('easeIn(0) is about 0', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(0), 0, 0.0001);
+    });
+    it('easeIn(.250000) is about .093460', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(0.25), 0.09346, 0.0001);
+    });
+    it('easeIn(.333333) is about .156164', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(0.333333), 0.156164, 0.0001);
+    });
+    it('easeIn(.500000) is about .315355', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(0.5), 0.315355, 0.0001);
+    });
+    it('easeIn(.666667) is about .511649', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(0.666667), 0.511649, 0.0001);
+    });
+    it('easeIn(.750000) is about .621854', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(0.75), 0.621854, 0.0001);
+    });
+    it('easeIn(1) is about 1', () => {
+        assert.approximately(cubicBezier(0.42, 0, 1, 1)(1), 1, 0.0001);
+    });
+
+    // test easeOut as cubic bezier
+    it('easeOut(0) is about 0', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(0), 0, 0.0001);
+    });
+    it('easeOut(.250000) is about .378146', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(0.25), 0.378146, 0.0001);
+    });
+    it('easeOut(.333333) is about .488351', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(0.333333), 0.488351, 0.0001);
+    });
+    it('easeOut(.500000) is about .684645', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(0.5), 0.684645, 0.0001);
+    });
+    it('easeOut(.666667) is about .843836', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(0.666667), 0.843836, 0.0001);
+    });
+    it('easeOut(.750000) is about .906540', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(0.75), 0.90654, 0.0001);
+    });
+    it('easeOut(1) is about 1', () => {
+        assert.approximately(cubicBezier(0, 0, 0.58, 1)(1), 1, 0.0001);
+    });
+
+    // test easeInOut as cubicBezier
+    it('easeInOut(0) is about 0', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(0), 0, 0.0001);
+    });
+    it('easeInOut(.250000) is about .129164', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(0.25), 0.129164, 0.0001);
+    });
+    it('easeInOut(.333333) is about .231776', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(0.333333), 0.231776, 0.0001);
+    });
+    it('easeInOut(.500000) is about .500000', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(0.5), 0.5, 0.0001);
+    });
+    it('easeInOut(.666667) is about .768224', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(0.666667), 0.768224, 0.0001);
+    });
+    it('easeInOut(.750000) is about .870836', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(0.75), 0.870836, 0.0001);
+    });
+    it('easeInOut(1) is about 1', () => {
+        assert.approximately(cubicBezier(0.42, 0, 0.58, 1)(1), 1, 0.0001);
+    });
+});

--- a/tests/easings/bounce.ts
+++ b/tests/easings/bounce.ts
@@ -1,0 +1,74 @@
+import { bounce } from '../../src/easings/bounce';
+import { assert } from 'chai';
+
+describe('bounce.in()', () => {
+    it('bounce.in(.000000) is about 0', () => {
+        assert.approximately(bounce.in(0.0), 0, 0.0001);
+    });
+    it('bounce.in(.250000) is about .02734375', () => {
+        assert.approximately(bounce.in(0.25), 0.02734375, 0.0001);
+    });
+    it('bounce.in(.333333) is about .13888888888888873', () => {
+        assert.approximately(bounce.in(0.333333), 0.13888888888888873, 0.0001);
+    });
+    it('bounce.in(.500000) is about .234375', () => {
+        assert.approximately(bounce.in(0.5), 0.234375, 0.0001);
+    });
+    it('bounce.in(.666667) is about .1597222222222221', () => {
+        assert.approximately(bounce.in(0.666667), 0.1597222222222221, 0.0001);
+    });
+    it('bounce.in(.750000) is about .52734375', () => {
+        assert.approximately(bounce.in(0.75), 0.52734375, 0.0001);
+    });
+    it('bounce.in(1.000000) is about 1', () => {
+        assert.approximately(bounce.in(1.0), 1, 0.0001);
+    });
+});
+
+describe('bounce.inOut()', () => {
+    it('bounce.inOut(.000000) is about 0', () => {
+        assert.approximately(bounce.inOut(0.0), 0, 0.0001);
+    });
+    xit('bounce.inOut(.250000) is about .1171875', () => {
+        assert.approximately(bounce.inOut(0.25), 0.1171875, 0.0001);
+    });
+    xit('bounce.inOut(.333333) is about .07986111111111105', () => {
+        assert.approximately(bounce.inOut(0.333333), 0.07986111111111105, 0.0001);
+    });
+    xit('bounce.inOut(.500000) is about .5', () => {
+        assert.approximately(bounce.inOut(0.5), 0.5, 0.0001);
+    });
+    xit('bounce.inOut(.666667) is about .9201388888888886', () => {
+        assert.approximately(bounce.inOut(0.666667), 0.9201388888888886, 0.0001);
+    });
+    xit('bounce.inOut(.750000) is about .8828125', () => {
+        assert.approximately(bounce.inOut(0.75), 0.8828125, 0.0001);
+    });
+    xit('bounce.inOut(1.000000) is about 1', () => {
+        assert.approximately(bounce.inOut(1.0), 1, 0.0001);
+    });
+});
+
+describe('bounce.out()', () => {
+    it('bounce.out(.000000) is about 0', () => {
+        assert.approximately(bounce.out(0.0), 0, 0.0001);
+    });
+    it('bounce.out(.250000) is about .47265625', () => {
+        assert.approximately(bounce.out(0.25), 0.47265625, 0.0001);
+    });
+    it('bounce.out(.333333) is about .8402777777777777', () => {
+        assert.approximately(bounce.out(0.333333), 0.8402777777777777, 0.0001);
+    });
+    it('bounce.out(.500000) is about .765625', () => {
+        assert.approximately(bounce.out(0.5), 0.765625, 0.0001);
+    });
+    it('bounce.out(.666667) is about .8611111111111112', () => {
+        assert.approximately(bounce.out(0.666667), 0.8611111111111112, 0.0001);
+    });
+    it('bounce.out(.750000) is about .97265625', () => {
+        assert.approximately(bounce.out(0.75), 0.97265625, 0.0001);
+    });
+    it('bounce.out(1.000000) is about 1', () => {
+        assert.approximately(bounce.out(1.0), 1, 0.0001);
+    });
+});


### PR DESCRIPTION
I added tests from just-curves over for back, bounce, and cubicBezier.  For some reason the results are significantly different for backInOut and bounceInOut.  I have marked those tests with xit() to prevent them from failing until we can investigate where the math is different and why. 